### PR TITLE
Allow cleanup to fail in spec

### DIFF
--- a/shoes-core/spec/shoes/console_spec.rb
+++ b/shoes-core/spec/shoes/console_spec.rb
@@ -121,6 +121,15 @@ describe Shoes::Console do
   end
 
   describe '#save', no_swt: true do
+    after do
+      begin
+        File.delete(mock_dialog)
+      rescue Errno::EACCES
+        # AppVeyor doesn't allow deletions on all paths, so if it fails
+        # Let it go, let it go, can't hold it back anymore!
+      end
+    end
+
     it 'must create file with contents of @formatted_messages and return character count' do
       console.instance_variable_set(:@messages, sample_message_array.dup)
       console.create_app
@@ -129,7 +138,6 @@ describe Shoes::Console do
 
       expect(returned_character_count).to eq(formatted_message_output.length)
       expect(File.open(mock_dialog, 'r').read).to eq(formatted_message_output)
-      File.delete(mock_dialog)
     end
   end
 


### PR DESCRIPTION
Finally got back around to looking at that spec and it seems AppVeyor allows file writing but not deletion on those directories. Honestly not a big deal, so wrapped it up in an `after` (to clarify it was a cleanup thing, not really part of the spec itself) and let it bounce on permission failures.

Doing a little local testing, but if you're happy with that and we're all ✅ then I think at long last we might be ready to merge https://github.com/shoes/shoes4/pull/1447!